### PR TITLE
Removed classes not required when showing the edit form, to avoid double...

### DIFF
--- a/templates/GridFieldDetailFormWithSearch.ss
+++ b/templates/GridFieldDetailFormWithSearch.ss
@@ -1,6 +1,6 @@
-<div class="cms-content cms-tabset center RatesAdmin ModelAdmin LeftAndMain ui-tabs ui-widget ui-widget-content ui-corner-all" data-layout-type="border" data-pjax-fragment="Content" style="left: 160px; top: 0px; width: 990px; height: 811px; position: absolute;">
+<div class="cms-content cms-tabset center RatesAdmin LeftAndMain ui-tabs ui-widget ui-widget-content ui-corner-all" data-layout-type="border" data-pjax-fragment="Content" style="left: 160px; top: 0px; width: 990px; height: 811px; position: absolute;">
 
-	<div class="cms-content-fields center ui-widget-content" data-layout-type="border">
+	<div class="center ui-widget-content" data-layout-type="border">
 		<div class="cms-content-tools west cms-panel cms-panel-layout" id="cms-content-tools-ModelAdmin" data-expandOnClick="true" data-layout-type="border">
 			<div class="cms-panel-content center">
 					<h3 class="cms-panel-header"><% _t('ModelAdmin_Tools.ss.FILTER', 'Filter') %></h3>


### PR DESCRIPTION
... up of css application. This is to avoid an issue where the edit form doesn't have any scroll bars if the number of fields is large.
